### PR TITLE
修复无法通过tag query文章bug

### DIFF
--- a/_data/variables.yml
+++ b/_data/variables.yml
@@ -42,7 +42,7 @@ default:
 sources:
   bootcdn:
     font_awesome: 'https://use.fontawesome.com/releases/v5.0.13/css/all.css'
-    jquery: 'https://cdn.bootcss.com/jquery/3.1.1/jquery.min.js'
+    jquery: 'https://cdn.jsdelivr.net/npm/jquery@3.1.1/dist/jquery.min.js'
     leancloud_js_sdk: '//cdn.jsdelivr.net/npm/leancloud-storage@3.13.2/dist/av-min.js'
     chart: 'https://cdn.bootcss.com/Chart.js/2.7.2/Chart.bundle.min.js'
     gitalk:

--- a/docs/_data/variables.yml
+++ b/docs/_data/variables.yml
@@ -42,7 +42,7 @@ default:
 sources:
   bootcdn:
     font_awesome: 'https://use.fontawesome.com/releases/v5.0.13/css/all.css'
-    jquery: 'https://cdn.bootcss.com/jquery/3.1.1/jquery.min.js'
+    jquery: 'https://cdn.jsdelivr.net/npm/jquery@3.1.1/dist/jquery.min.js'
     leancloud_js_sdk: '//cdn.jsdelivr.net/npm/leancloud-storage@3.13.2/dist/av-min.js'
     chart: 'https://cdn.bootcss.com/Chart.js/2.7.2/Chart.bundle.min.js'
     gitalk:

--- a/test/_data/variables.yml
+++ b/test/_data/variables.yml
@@ -42,7 +42,7 @@ default:
 sources:
   bootcdn:
     font_awesome: 'https://use.fontawesome.com/releases/v5.0.13/css/all.css'
-    jquery: 'https://cdn.bootcss.com/jquery/3.1.1/jquery.min.js'
+    jquery: 'https://cdn.jsdelivr.net/npm/jquery@3.1.1/dist/jquery.min.js'
     leancloud_js_sdk: '//cdn.jsdelivr.net/npm/leancloud-storage@3.13.2/dist/av-min.js'
     chart: 'https://cdn.bootcss.com/Chart.js/2.7.2/Chart.bundle.min.js'
     gitalk:


### PR DESCRIPTION
1. bug原因是因为使用了无法访问的jquery.min.js脚本,替换为国内可访问的